### PR TITLE
Add automatic subscription reconnection for network disconnections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2025-10-26
+
+### Added
+- **Automatic Subscription Reconnection**: Client now automatically resubscribes to all active queries after network disconnections
+  - `NetworkMonitor` using `Network.framework` detects network state changes (iOS 13.0+, macOS 10.15+)
+  - Subscriptions are tracked internally and automatically reestablished on reconnection
+  - Works seamlessly with WiFi ↔ Cellular switches, airplane mode, and Mac laptop sleep/wake
+  - Fixes infinite loading spinner issue when network connection is lost and restored
+- **Manual Reconnection API**: New public `reconnect()` method for manual control
+  - Useful for app lifecycle events (e.g., `applicationWillEnterForeground`)
+  - Allows custom network detection logic
+  - Helpful for testing reconnection behavior
+- Comprehensive tests for reconnection scenarios
+
+### Fixed
+- **Critical**: Subscriptions no longer hang after network disconnection and reconnection
+  - Previously subscriptions would show infinite loading spinner after Mac sleep/wake
+  - Previously subscriptions would not update after WiFi disconnect/reconnect
+  - Network monitoring now correctly triggers resubscription
+- Subscription cleanup now properly removes canceled subscriptions from tracking
+
+### Technical Details
+- `ConvexClient` now tracks all active subscriptions internally
+- `NetworkMonitor` class monitors network path changes via `NWPathMonitor`
+- Automatic resubscription happens on network state transition from disconnected to connected
+- Weak references to subscription adapters prevent memory leaks
+- Thread-safe subscription tracking with `NSLock`
+
 ## [0.6.0] - 2025-10-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,6 +82,34 @@ extension MyAuthProvider {
 
 If your `AuthProvider` doesn't implement `refreshToken(from:)`, the app will continue to work normally. Tokens will eventually expire, requiring the user to log in again. This is handled by the default implementation that throws `AuthProviderError.refreshNotSupported`.
 
+## Automatic Reconnection
+
+The client automatically handles network disconnections and reconnections, ensuring your subscriptions continue to work seamlessly.
+
+### How It Works
+
+- **Network Monitoring**: The client uses iOS `Network.framework` to monitor network connectivity changes
+- **Automatic Resubscription**: When network connectivity is restored, all active subscriptions are automatically reestablished
+- **Background Resilience**: Works across app lifecycle events like backgrounding, Mac laptop closing, WiFi/Cellular switching
+
+### Manual Reconnection
+
+For edge cases or to force reconnection, you can manually trigger reconnection:
+
+```swift
+// After detecting the app returned from background
+client.reconnect()
+```
+
+This is useful in scenarios like:
+- App returning from background (`applicationWillEnterForeground`)
+- Custom network detection logic
+- Testing reconnection behavior
+
+### Requirements
+
+- **iOS 13.0+** or **macOS 10.15+** for automatic network monitoring
+- On older platforms, use manual `reconnect()` calls when needed
 
 ## Building
 


### PR DESCRIPTION
## Summary

Implements automatic resubscription of queries when network connectivity is restored, fixing the infinite loading spinner issue after network interruptions.

## Features

- **NetworkMonitor** using Network.framework for connectivity detection (iOS 13.0+, macOS 10.15+)
- **Automatic subscription tracking** in ConvexClient
- Subscriptions automatically reestablish when network reconnects
- **Manual reconnect() API** for app lifecycle integration
- Works seamlessly with WiFi↔Cellular, airplane mode, Mac sleep/wake
- Thread-safe subscription tracking with NSLock

## Changes

- Add NetworkMonitor class for network path monitoring
- Add subscription tracking to ConvexClient (UUID-based)
- Extend subscribe() to register and track active subscriptions
- Implement resubscribeAll() for automatic reconnection
- Add public reconnect() method for manual control
- NetworkMonitor disabled for test clients to avoid test flakiness
- Add comprehensive tests for reconnection scenarios
- Update README with reconnection documentation
- Update CHANGELOG with detailed feature description

## API Documentation

Added comprehensive DocC documentation for the new `reconnect()` public API:

```swift
/// Manually reconnects all active subscriptions.
///
/// The client automatically monitors network connectivity and reconnects
/// subscriptions when the network is restored, so manual reconnection is
/// typically not needed.
public func reconnect()
```

## Testing

- ✅ All 22 unit tests pass
- ✅ All 10 integration tests pass
- ✅ NetworkMonitor only runs in integration tests (not unit tests)
- ✅ Tested on iOS Simulator and macOS

## Fixes

- **Critical**: Infinite loading spinner after Mac laptop sleep/wake
- **Critical**: Subscriptions not updating after WiFi disconnect/reconnect
- Data not refreshing after network state changes
- Missing reconnection handling reported by Discord users

## Dependencies

This PR builds on top of #6 (JWT Token Refresh). It can be reviewed independently but should be merged after #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)