### PR TITLE
Allow injecting an auth token provider on the base ConvexClient

### DIFF
--- a/Sources/ConvexMobile/AuthToken.swift
+++ b/Sources/ConvexMobile/AuthToken.swift
@@ -1,0 +1,66 @@
+//
+//  AuthToken.swift
+//  ConvexMobile
+//
+//  Token injection on the base ConvexClient.
+//
+
+import Foundation
+
+/// Supplies the JWT that `ConvexClient` sends with authenticated calls.
+///
+/// Implement this to drive Convex auth from an identity provider you already
+/// manage, without adopting ``ConvexClientWithAuth``. That subclass owns the
+/// whole login lifecycle — sign-in strategies, cached sessions, an auth state
+/// publisher — which is convenient when it fits and awkward when the app
+/// already has its own auth layer and only needs to hand Convex a token.
+///
+/// `fetchToken` is called by the Rust core when it needs a token, including
+/// after a reconnect. Returning `nil` means "no valid token right now", which
+/// leaves the connection unauthenticated rather than failing.
+///
+/// - Parameter forceRefresh: `true` when the previous token was rejected, so a
+///   cached value should not be reused.
+public protocol ConvexAuthTokenProvider: Sendable {
+    func fetchToken(forceRefresh: Bool) async throws -> String?
+}
+
+extension ConvexClient {
+    /// Sets or clears the provider supplying auth tokens for this client.
+    ///
+    /// Pass `nil` to return to unauthenticated calls, e.g. on sign-out.
+    ///
+    /// Unlike ``ConvexClientWithAuth``, this stores no mutable auth state on the
+    /// client: the provider is handed straight to the Rust core, which owns
+    /// refresh. Callers that need serialisation across sign-in, sign-out and
+    /// token refresh should make their provider an `actor`.
+    public func setAuthTokenProvider(
+        _ provider: (any ConvexAuthTokenProvider)?
+    ) async throws {
+        guard let provider else {
+            try await ffiClient.setAuthCallback(provider: nil)
+            return
+        }
+        try await ffiClient.setAuthCallback(
+            provider: ExternalAuthTokenProvider(wrapping: provider)
+        )
+    }
+}
+
+/// Adapts a public ``ConvexAuthTokenProvider`` to the UniFFI-generated protocol,
+/// so callers never have to import or conform to generated types.
+///
+/// A `final class` because the generated protocol requires `AnyObject`.
+/// `@unchecked Sendable` is safe here: the single stored property is a `let`
+/// holding a `Sendable` value, so there is no mutable state to race on.
+private final class ExternalAuthTokenProvider: AuthTokenProvider, @unchecked Sendable {
+    private let wrapped: any ConvexAuthTokenProvider
+
+    init(wrapping wrapped: any ConvexAuthTokenProvider) {
+        self.wrapped = wrapped
+    }
+
+    func fetchToken(forceRefresh: Bool) async throws -> String? {
+        try await wrapped.fetchToken(forceRefresh: forceRefresh)
+    }
+}


### PR DESCRIPTION
## What

Adds a public `ConvexAuthTokenProvider` protocol and
`ConvexClient.setAuthTokenProvider(_:)`, so an app can supply Convex with a JWT
without adopting `ConvexClientWithAuth`.

## Why

`ConvexClientWithAuth` is currently the only public way to authenticate, and it
owns the entire login lifecycle: sign-in strategies, `loginFromCache`, an auth
state publisher. That's convenient when it fits. It leaves no option for an app
that already manages identity elsewhere — an existing auth layer, a shared token
store, a provider with its own SDK — and only needs to hand Convex a token.

Today such an app has to either adopt the whole `AuthProvider` protocol to
satisfy a client it isn't really using, or reach for `ffiClient`, which is
module-internal.

There's a second benefit. #21 reports that `authBridge` is mutated from three
concurrent contexts without synchronisation, with failure modes of
`EXC_BAD_ACCESS` or auth silently resetting to unauthenticated. This path stores
no mutable auth state on the client at all, so a caller can make their provider
an `actor` and have sign-in, sign-out and refresh serialise by construction.
That doesn't fix #21, but it gives affected apps a supported way around it.

## Design

- The provider is handed straight to the Rust core's existing
  `setAuthCallback`, so refresh semantics — including `forceRefresh` after a
  rejected token — are exactly what `ConvexClientWithAuth` already gets.
- A small internal adapter conforms the public protocol to the UniFFI-generated
  one, so callers never import or conform to generated types.
- Passing `nil` clears the provider, matching the existing logout path.

## Compatibility

Purely additive. `ConvexClientWithAuth` is untouched, no existing signatures
change, and the generated protocol stays internal.

## Usage

```swift
actor MyAuth: ConvexAuthTokenProvider {
    func fetchToken(forceRefresh: Bool) async throws -> String? {
        try await identityProvider.token(forceRefresh: forceRefresh)
    }
}

try await client.setAuthTokenProvider(MyAuth())
```

## Testing

Built against 0.8.1 and exercised in an iOS app talking to a live deployment:
a Clerk session token supplied through this path is accepted by Convex, and the
same call fails with "Not authenticated" when the provider is cleared.

I haven't added unit tests — the existing auth tests are built around
`ConvexClientWithAuth`'s state machine and there's no fake for
`MobileConvexClientProtocol.setAuthCallback` to assert against. Happy to add
coverage if you'd like it, in whatever shape suits the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
