### PR TITLE
Add iOS Simulator test coverage (build + connectivity regression)

### DIFF
--- a/.github/workflows/ios-simulator.yml
+++ b/.github/workflows/ios-simulator.yml
@@ -1,0 +1,49 @@
+name: iOS Simulator Tests
+
+# Builds and runs the test suite on the iOS Simulator destination. `swift test`
+# only ever exercises the macOS slice of the vendored xcframework; this job is
+# what actually verifies the library works in the iOS Simulator (i.e. that a
+# `wss://` subscription connects and resolves there, rather than "refreshing"
+# forever).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  # The integration tests mutate a shared Convex test deployment, so serialize runs.
+  group: ios-simulator
+  cancel-in-progress: false
+
+jobs:
+  ios-simulator:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      # macos-15 runners default to Xcode 16+, which provides swift-testing
+      # (`import Testing`). Print it for the record.
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Pick an available iPhone simulator
+        id: sim
+        run: |
+          udid=$(xcrun simctl list devices available -j \
+            | python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; \
+ids=[dev['udid'] for rt,devs in d.items() if 'iOS' in rt for dev in devs \
+if dev.get('isAvailable') and dev['name'].startswith('iPhone')]; \
+print(ids[-1] if ids else '')")
+          if [ -z "$udid" ]; then echo "no iOS simulator available" >&2; exit 1; fi
+          echo "udid=$udid" >> "$GITHUB_OUTPUT"
+          xcrun simctl boot "$udid" || true
+
+      - name: Test on iOS Simulator
+        # IPHONEOS_DEPLOYMENT_TARGET is raised only for the build so the tests can
+        # use iOS 15 `AsyncPublisher.values`; the library itself still supports iOS 13.
+        run: |
+          xcodebuild test \
+            -scheme ConvexMobile \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            IPHONEOS_DEPLOYMENT_TARGET=15.0

--- a/Tests/ConvexMobileTests/SimulatorConnectivityTests.swift
+++ b/Tests/ConvexMobileTests/SimulatorConnectivityTests.swift
@@ -1,0 +1,59 @@
+import Combine
+import XCTest
+
+import ConvexMobile
+
+/// Guards against a class of regression where ConvexMobile query subscriptions
+/// never resolve on the iOS Simulator — the app sits "refreshing over and over"
+/// because the `wss://` connection never establishes and no query update is
+/// delivered.
+///
+/// The rest of the suite (`IntegrationTests`) uses iOS 15 `AsyncPublisher.values`
+/// and, historically, only ever ran on macOS. This test is written with
+/// iOS 13-compatible Combine APIs and is meant to run on the **iOS Simulator**
+/// destination so the transport is exercised there in CI, over a real cloud
+/// (`wss://`) deployment.
+final class SimulatorConnectivityTests: XCTestCase {
+  private var cancellables = Set<AnyCancellable>()
+
+  private struct Message: Decodable, Equatable {
+    let author: String
+    let body: String
+  }
+
+  private let deploymentUrl = "https://curious-lynx-309.convex.cloud"
+
+  func testSubscriptionResolvesOverTLS() {
+    let client = ConvexClient(deploymentUrl: deploymentUrl)
+
+    let connected = expectation(description: "websocket reached .connected")
+    let gotInitialValue = expectation(description: "received initial messages:list value")
+
+    // Attach the websocket-state observer before triggering a connect (via
+    // subscribe) so we don't miss the .connecting -> .connected transition.
+    client.watchWebSocketState()
+      .sink { state in
+        NSLog("ConvexConnectivity websocket state: \(state)")
+        if state == .connected { connected.fulfill() }
+      }
+      .store(in: &cancellables)
+
+    let subscription: AnyPublisher<[Message]?, ClientError> =
+      client.subscribe(to: "messages:list")
+    subscription
+      .sink(
+        receiveCompletion: { completion in
+          if case .failure(let error) = completion {
+            XCTFail("subscription failed before delivering a value: \(error)")
+            gotInitialValue.fulfill()
+          }
+        },
+        receiveValue: { _ in
+          gotInitialValue.fulfill()
+        }
+      )
+      .store(in: &cancellables)
+
+    wait(for: [connected, gotInitialValue], timeout: 30)
+  }
+}


### PR DESCRIPTION
## Why

`swift test` only ever runs against the **macOS** slice of the vendored `libconvexmobile-rs.xcframework`, so nothing in this repo actually verified the library in the **iOS Simulator**. That's the "we don't have an iOS simulator build" gap — and it means a transport regression that only shows up in the simulator (the app sitting on "refreshing" forever because a `wss://` subscription never connects) could ship unnoticed.

## What

Purely additive — `Package.swift` and the library sources are untouched (public iOS 13 floor unchanged):

- **`.github/workflows/ios-simulator.yml`** — runs `xcodebuild test` on an iOS Simulator destination. It raises `IPHONEOS_DEPLOYMENT_TARGET=15.0` **for the test build only**, because the existing integration tests use iOS 15 `AsyncPublisher.values`; the library itself still supports iOS 13.
- **`Tests/ConvexMobileTests/SimulatorConnectivityTests.swift`** — an iOS 13-compatible (Combine `.sink`) regression test that subscribes to `messages:list` over a real cloud (`wss://`) deployment and asserts the socket reaches `.connected` and the query resolves. Fails loudly if the simulator ever regresses to "refreshing" forever.

## Verified

Ran locally on an iPhone 17 simulator (iOS 26.5): **all 11 integration tests + all unit tests + the new connectivity test pass**; websocket goes `connecting → connected` in ~0.5s.

To run the iOS-sim tests locally:

```sh
xcodebuild test -scheme ConvexMobile \
  -destination 'platform=iOS Simulator,name=iPhone 17' \
  IPHONEOS_DEPLOYMENT_TARGET=15.0
```

> Note: the integration tests mutate the shared `curious-lynx-309` test deployment, so the workflow serializes runs via a concurrency group (same backend the existing suite already uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)