### PR TITLE
Fix FFI retain cycle that keeps discarded clients (and their websockets) alive until process exit

### DIFF
--- a/Sources/ConvexMobile/ConvexMobile.swift
+++ b/Sources/ConvexMobile/ConvexMobile.swift
@@ -329,9 +329,18 @@ public class ConvexClientWithAuth<T>: ConvexClient {
   ///
   /// This handler is passed to the auth provider during login and should be called
   /// whenever a fresh token is available or when the session becomes invalid.
+  ///
+  /// `ffiClient` MUST be captured weakly here: the handler is captured by the
+  /// ``AuthTokenProviderBridge``'s refresh closure, and the Rust client stores
+  /// that bridge when it is passed to `setAuthCallback`. A strong `ffiClient`
+  /// capture therefore forms a retain cycle across the FFI boundary
+  /// (Rust client -> bridge -> this handler -> `ffiClient` proxy -> Rust
+  /// client) that keeps a discarded client's Rust core (its tokio runtime and
+  /// its websocket) alive until process exit.
   private func onIdTokenHandler() -> @Sendable (String?) -> Void {
-    { [ffiClient, authPublisher, weak self] token in
+    { [weak ffiClient, authPublisher, weak self] token in
       Task {
+        guard let ffiClient else { return }
         do {
           if let token {
             await self?.authBridge?.updateToken(token)

--- a/Sources/ConvexMobile/ConvexMobile.swift
+++ b/Sources/ConvexMobile/ConvexMobile.swift
@@ -152,9 +152,21 @@ public class ConvexClient {
   }
 
   typealias RemoteCall = (String, [String: String]) async throws -> String
-  
+
   public func watchWebSocketState() -> AnyPublisher<WebSocketState, Never> {
     return webSocketStateAdapter.newPublisher()
+  }
+
+  /// Explicitly tears down this client before it is discarded, so that
+  /// releasing the last Swift reference deterministically frees the underlying
+  /// Rust client, closing its websocket and shutting down its runtime.
+  ///
+  /// A plain ``ConvexClient`` holds no teardown-requiring state, so this is a
+  /// no-op; ``ConvexClientWithAuth`` overrides it to clear the auth callback
+  /// registered with the Rust core. Call it before dropping a client you are
+  /// replacing (e.g. a reconnect that recreates the client). The client must
+  /// not be used again after calling `close()`.
+  public func close() async {
   }
 }
 
@@ -322,6 +334,20 @@ public class ConvexClientWithAuth<T>: ConvexClient {
       dump(error)
       authPublisher.send(AuthState.unauthenticated)
       return Result.failure(error)
+    }
+  }
+
+  /// See ``ConvexClient/close()``. Clears the auth callback registered with
+  /// the Rust core (and the bridge held by this instance) WITHOUT logging the
+  /// user out, so that discarding the client actually frees it. Unlike
+  /// ``logout()`` this has no side effects on the ``AuthProvider``'s stored
+  /// credentials and does not change ``authState``.
+  override public func close() async {
+    authBridge = nil
+    do {
+      try await ffiClient.setAuthCallback(provider: nil)
+    } catch {
+      dump(error)
     }
   }
 

--- a/Tests/ConvexMobileTests/ClientReleaseTests.swift
+++ b/Tests/ConvexMobileTests/ClientReleaseTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+@testable import ConvexMobile
+@testable import UniFFI
+
+/// Proves a discarded client can actually be freed, i.e. that the auth wiring
+/// does not retain the FFI client once the app drops its references.
+///
+/// The real-world failure this guards against: the token handler created in
+/// `onIdTokenHandler` used to capture `ffiClient` strongly. That handler is
+/// captured by the `AuthTokenProviderBridge`'s refresh closure, and the Rust
+/// core stores the bridge when it is passed to `setAuthCallback`: a retain
+/// cycle across the FFI boundary. Since the `ffiClient` proxy's deinit is what
+/// frees the Rust client, the cycle kept every discarded client's Rust core
+/// (its own tokio runtime + established websocket) alive until process exit.
+/// An app that recreated clients to recover from wedged connections leaked one
+/// server-side websocket per recreate (41 observed in a single macOS session).
+///
+/// `FakeMobileConvexClient` stores the provider passed to `setAuthCallback`
+/// strongly, exactly like the Rust core does, so the cycle is reproducible
+/// entirely in Swift.
+final class ClientReleaseTests: XCTestCase {
+
+  /// The original leak: the client is discarded while the fake (like the Rust
+  /// core) still holds the bridge. The handler's weak `ffiClient` capture is
+  /// the only thing preventing the cycle.
+  func testFFIClientReleasedAfterLoginWithoutClose() async throws {
+    var fake: FakeMobileConvexClient? = FakeMobileConvexClient()
+    weak var weakFake = fake
+    var client: ConvexClientWithAuth<String>? = ConvexClientWithAuth(
+      ffiClient: fake!, authProvider: FakeAuthProvider())
+
+    let result = await client!.login()
+    XCTAssertNotNil(try? result.get())
+    XCTAssertNotNil(fake!.authProvider, "login should install the auth bridge")
+
+    client = nil
+    fake = nil
+    // Let the handler's fire-and-forget Tasks (spawned during login) drain;
+    // they hold a transient strong reference while running.
+    try await Task.sleep(nanoseconds: 200_000_000)
+
+    XCTAssertNil(
+      weakFake,
+      "FFI client is retained after all references were dropped: the bridge -> "
+        + "token handler -> ffiClient retain cycle is back, and every discarded "
+        + "real client will leak its Rust core + websocket")
+  }
+}

--- a/Tests/ConvexMobileTests/ClientReleaseTests.swift
+++ b/Tests/ConvexMobileTests/ClientReleaseTests.swift
@@ -46,4 +46,30 @@ final class ClientReleaseTests: XCTestCase {
         + "token handler -> ffiClient retain cycle is back, and every discarded "
         + "real client will leak its Rust core + websocket")
   }
+
+  /// `close()` clears the callback stored in the (fake) Rust core without
+  /// touching the auth provider: the explicit teardown for clients being
+  /// replaced.
+  func testCloseClearsAuthCallbackAndReleasesClient() async throws {
+    var fake: FakeMobileConvexClient? = FakeMobileConvexClient()
+    weak var weakFake = fake
+    let provider = FakeAuthProvider()
+    var client: ConvexClientWithAuth<String>? = ConvexClientWithAuth(
+      ffiClient: fake!, authProvider: provider)
+
+    let result = await client!.login()
+    XCTAssertNotNil(try? result.get())
+    XCTAssertNotNil(fake!.authProvider)
+
+    await client!.close()
+    XCTAssertNil(fake!.authProvider, "close() must clear the stored auth callback")
+    XCTAssertEqual(
+      provider.logoutCallCount, 0,
+      "close() must not log the user out, it only tears down the client")
+
+    client = nil
+    fake = nil
+    try await Task.sleep(nanoseconds: 200_000_000)
+    XCTAssertNil(weakFake, "FFI client must deallocate after close() + release")
+  }
 }

--- a/Tests/ConvexMobileTests/ConvexMobileTests.swift
+++ b/Tests/ConvexMobileTests/ConvexMobileTests.swift
@@ -549,6 +549,7 @@ class FakeAuthProvider: AuthProvider {
 
   private var storedOnIdToken: (@Sendable (String?) -> Void)?
   var loginFromCacheCallCount = 0
+  var logoutCallCount = 0
 
   func loginFromCache(onIdToken: @Sendable @escaping (String?) -> Void) async throws -> String {
     loginFromCacheCallCount += 1
@@ -564,7 +565,7 @@ class FakeAuthProvider: AuthProvider {
   }
 
   func logout() async throws {
-
+    logoutCallCount += 1
   }
 
   func extractIdToken(from authResult: String) -> String {


### PR DESCRIPTION
## Summary

`ConvexClientWithAuth` forms a retain cycle across the FFI boundary the moment `login()` / `loginFromCache()` runs, so a discarded client can never be freed: its Rust core (the client's private multi-threaded tokio runtime **and its established websocket**) survives until the process exits. Any app that replaces its client, which is the documented workaround for a dead connection since there is no `disconnect()` API, leaks one server-side websocket plus a set of OS threads per replacement.

This PR fixes the cycle (commit 1) and adds an explicit `close()` teardown for the replace-the-client pattern (commit 2, separable if you'd prefer just the fix).

## The cycle

The token handler created in `onIdTokenHandler` captures `ffiClient` **strongly** (note the same capture list already says `weak self`):

```swift
{ [ffiClient, authPublisher, weak self] token in ...
```

That handler is captured by `AuthTokenProviderBridge`'s `getValidToken` closure, and the Rust core stores the bridge when it's passed to `setAuthCallback` (in convex-mobile's `internal_set_auth_callback`, the `AuthTokenFetcher` closure holds the `Arc<dyn AuthTokenProvider>`). So:

```
Rust MobileConvexClient (stored auth fetcher)
  -> AuthTokenProviderBridge   (Swift, pinned in the UniFFI handle map)
  -> token handler             (captures ffiClient strongly)
  -> ffiClient proxy           (its deinit is the ONLY thing that frees the Rust Arc)
  -> Arc<MobileConvexClient>   (owns the tokio Runtime + websocket)
```

Neither side can release the other. Dropping every app-side reference frees nothing, and since `MobileConvexClient` owns its own `tokio::runtime::Runtime` and has no `Drop` impl beyond the default, the runtime and socket live on.

## Real-world impact

Observed in a macOS app (self-hosted backend) that recreates its client on system wake / network-interface changes:

- Quitting the app closed **41 websockets at a single instant**: the backend logged 41 `Client disconnected` warnings with the same timestamp, one per client recreation that session.
- A freshly launched app holds exactly **1** established socket, confirming the accumulation came from discarded clients.
- Each leaked client also pins a dedicated multi-threaded tokio runtime, i.e. leaked OS threads. That is a real cost even at count = 1 (e.g. a sign-out/sign-in flow that rebuilds the client).

## The fix

**Commit 1** captures `ffiClient` weakly, mirroring the existing `weak self`. Behavior is unchanged for a live client; if the client has been discarded, a late token push now no-ops instead of resurrecting a zombie. A doc comment marks the weak capture as load-bearing.

**Commit 2** adds `ConvexClient.close()`: a no-op on the base class, overridden in `ConvexClientWithAuth` to clear the auth callback stored in the Rust core *without* touching the `AuthProvider`'s stored credentials or `authState` (unlike `logout()`). This gives the throw-away-and-recreate pattern a deterministic teardown even if something else transiently retains the old client. Happy to split this out or reshape the API if you'd prefer only the cycle fix.

## Tests

`ClientReleaseTests` reproduces the cycle entirely in Swift: the existing `FakeMobileConvexClient` already stores the provider passed to `setAuthCallback` strongly, which is exactly what the Rust core does, so the leak is testable without networking.

- `testFFIClientReleasedAfterLoginWithoutClose`: a discarded client's FFI proxy must deallocate even while the (fake) Rust core still holds the bridge. **Fails against the strong capture** with the cycle diagnosis, passes with commit 1.
- `testCloseClearsAuthCallbackAndReleasesClient`: `close()` clears the stored callback, does not call `logout` on the provider, and leaves the client releasable.

Full package test suite (unit + integration) passes.

## Note

The Kotlin bindings ([convex-mobile](https://github.com/get-convex/convex-mobile)/android) may warrant the same audit; I haven't verified whether their auth wiring has an equivalent capture.
